### PR TITLE
fix: disabled the monitoring for metrics call

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -31,7 +31,7 @@ spec:
             ASPNETCORE_URLS: "http://*:5000"
             AllowCorsDomains: "http://localhost:3000, https://frontend-oplog-web-dev.radix.equinor.com"
           replicas: 2
-          monitoring: true
+          monitoring: false
           resources:
             requests:
               memory: "256Mi"
@@ -48,7 +48,7 @@ spec:
             ASPNETCORE_URLS: "http://*:5000"
             AllowCorsDomains: "http://localhost:3000, https://frontend-oplog-web-prod.radix.equinor.com, https://oplog.equinor.com"
           replicas: 2
-          monitoring: true
+          monitoring: false
           resources:
             requests:
               memory: "256Mi"


### PR DESCRIPTION
fix: disabled the monitoring for metrics call. The metrics endpoint is queried by Radix to collect application specific metrics.
#135