### PR TITLE
chore: adjust memory and scaling in radixconfig

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -30,14 +30,13 @@ spec:
           variables:
             ASPNETCORE_URLS: "http://*:5000"
             AllowCorsDomains: "http://localhost:3000, https://frontend-oplog-web-dev.radix.equinor.com"
-          replicas: 2
+          replicas: 1
           monitoring: false
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
               cpu: "200m"
         - environment: prod
           identity: 
@@ -47,12 +46,18 @@ spec:
           variables:
             ASPNETCORE_URLS: "http://*:5000"
             AllowCorsDomains: "http://localhost:3000, https://frontend-oplog-web-prod.radix.equinor.com, https://oplog.equinor.com"
-          replicas: 2
+          horizontalScaling:
+            resources:
+                memory:
+                  averageUtilization: 75
+                cpu:
+                  averageUtilization: 85
+            minReplicas: 1
+            maxReplicas: 4
           monitoring: false
           resources:
             requests:
-              memory: "256Mi"
+              memory: "512Mi"
               cpu: "100m"
             limits:
-              memory: "512Mi"
               cpu: "200m"

--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -34,7 +34,7 @@ spec:
           monitoring: false
           resources:
             requests:
-              memory: "512Mi"
+              memory: "256Mi"
               cpu: "100m"
             limits:
               cpu: "200m"


### PR DESCRIPTION
Solves #170 

- Increase default memory request for API, as it always uses more than requested in prod. 
- Add horizontalScaling rules for increased performance during busy periods