### PR TITLE
chore: replace base image with -alpine

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,26 +1,39 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+# Use the .NET 8 SDK image based on Alpine
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /app
 
+# Install additional packages
+RUN apk add --no-cache libc6-compat icu
+
 # Copy csproj and restore as distinct layers
-# TODO: Copy only csproj
-COPY . .
+COPY ./Oplog.Api/Oplog.Api.csproj ./Oplog.Api/Oplog.Api.csproj
+COPY ./Oplog.Core/Oplog.Core.csproj ./Oplog.Core/Oplog.Core.csproj
+COPY ./Oplog.Persistence/Oplog.Persistence.csproj ./Oplog.Persistence/Oplog.Persistence.csproj
 
 RUN dotnet restore Oplog.Api/Oplog.Api.csproj
 
 # Copy everything else and build
-# TODO: Copy rest of files
-# COPY . ./
+COPY . ./
 RUN dotnet publish Oplog.Api -c Release -o Oplog.Api/out
 
-# Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+# Build runtime image based on Alpine
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
 WORKDIR /app
-COPY --from=build-env /app/Oplog.Api/out .
 
-RUN addgroup --gid 1001 radix-non-root-group
-RUN adduser --uid 1001 --gid 1001 radix-non-root-user
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+ENV TZ="Europe/Oslo"
+RUN apk -U add --no-cache icu tzdata
 
-USER 1001
+# Copy the published output from the build stage
+COPY --from=build /app/Oplog.Api/out .
+
+# Create a non-root user and group with numeric UID/GID
+RUN addgroup -g 1001 non-root-group && \
+    adduser -u 1001 -G non-root-group -s /bin/sh -D non-root-user
+
+# Switch to the non-root user
+USER 1001:1001
 
 EXPOSE 5000
+
 ENTRYPOINT ["dotnet", "Oplog.Api.dll"]


### PR DESCRIPTION
Solves #169 

Replace debian based image with -alpine to minimize the size of the image and resolve a (fake) vulnerability