### PR TITLE
fix: server generated times should use UtcNow. 

### DIFF
--- a/src/Oplog.Api/Oplog.Api.csproj
+++ b/src/Oplog.Api/Oplog.Api.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Graph" Version="5.52.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.3" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.18.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Oplog.Core/Commands/LogTemplates/CreateLogTemplateCommandHandler.cs
+++ b/src/Oplog.Core/Commands/LogTemplates/CreateLogTemplateCommandHandler.cs
@@ -25,7 +25,7 @@ public sealed class CreateLogTemplateCommandHandler : ICommandHandler<CreateLogT
             Subtype = command.SubType,
             IsCritical = command.IsCritical,
             CreatedBy = command.CreatedBy,
-            CreatedDate = DateTime.Now
+            CreatedDate = DateTime.UtcNow
         };
 
         await _templateRepository.Insert(newLogTemplate);

--- a/src/Oplog.Core/Commands/LogTemplates/UpdateLogTemplateCommandHandler.cs
+++ b/src/Oplog.Core/Commands/LogTemplates/UpdateLogTemplateCommandHandler.cs
@@ -28,7 +28,7 @@ public sealed class UpdateLogTemplateCommandHandler : ICommandHandler<UpdateLogT
         logtemplate.Subtype = command.SubType;
         logtemplate.IsCritical = command.IsCritical;
         logtemplate.UpdatedBy = command.UpdatedBy;
-        logtemplate.UpdatedDate = DateTime.Now;
+        logtemplate.UpdatedDate = DateTime.UtcNow;
 
         _logTemplateRepository.Update(logtemplate);
         await _logTemplateRepository.Save();

--- a/src/Oplog.Core/Commands/Logs/CreateLogCommandHandler.cs
+++ b/src/Oplog.Core/Commands/Logs/CreateLogCommandHandler.cs
@@ -28,7 +28,7 @@ public sealed class CreateLogCommandHandler : ICommandHandler<CreateLogCommand, 
             Text = command.Comment,
             EffectiveTime = command.EffectiveTime,
             CreatedBy = command.CreatedBy,
-            CreatedDate = DateTime.Now,
+            CreatedDate = DateTime.UtcNow,
             IsCritical = command.IsCritical
         };
 

--- a/src/Oplog.Core/Commands/Logs/UpdateLogCommandHandler.cs
+++ b/src/Oplog.Core/Commands/Logs/UpdateLogCommandHandler.cs
@@ -31,7 +31,7 @@ public sealed class UpdateLogCommandHandler : ICommandHandler<UpdateLogCommand, 
         logToUpdate.Subtype = command.SubType;
         logToUpdate.Text = command.Comment;
         logToUpdate.EffectiveTime = command.EffectiveTime;
-        logToUpdate.UpdatedDate = DateTime.Now;
+        logToUpdate.UpdatedDate = DateTime.UtcNow;
         logToUpdate.UpdatedBy = command.UpdatedBy;
         logToUpdate.IsCritical = command.IsCritical;
 


### PR DESCRIPTION
Replace DateTime.Now with DateTime.UtcNow

Also update a Microsoft.Identity.CLient to resolve vulnerability.

Resolves #177
